### PR TITLE
Make more stylistic changes to navigation bar

### DIFF
--- a/src/_components/navigation_section.erb
+++ b/src/_components/navigation_section.erb
@@ -1,15 +1,12 @@
-<!--leftsidebar navigation elements generating-->
-
 <li class="relative mt-6">
-  <h2 class="text-md font-black text-zinc-900 dark:text-white uppercase">
+  <h2 class="text-sm font-semibold text-zinc-900 dark:text-white uppercase">
     <%= @title %>
   </h2>
-  <div class=" flex w-full h-2 bg-green-500 bg-opacity-30"></div>
-  <div class="relative mt-3 pl-2">
+  <div class="relative mt-3">
     <ul role="list">
       <% @children.each do |k,v| %>
-        <li class="relative border-l-4 <% if equal_paths(v, @current_path) %>border-emerald-500 <% else %>border-transparent<% end %>">
-          <a class="flex justify-between gap-2 py-1 pr-3 text-sm transition pl-4 
+        <li class="relative border-l-2 <% if equal_paths(v, @current_path) %>border-emerald-500 <% else %>border-transparent<% end %>">
+          <a class="flex justify-between gap-2 py-1 pr-3 text-sm transition pl-4
           <% if equal_paths(v, @current_path) %>text-black dark:text-white font-semibold<% else %>text-zinc-600 dark:text-zinc-400 <% end %>
            hover:text-zinc-900 dark:hover:text-white" href="<%= v -%>">
             <span class="truncate"><%= k %></span>

--- a/src/_layouts/default.erb
+++ b/src/_layouts/default.erb
@@ -9,9 +9,10 @@
         <header
           class="contents lg:pointer-events-none lg:fixed lg:inset-0 lg:z-40 lg:flex"
           >
-          <div class="contents lg:pointer-events-auto lg:block lg:w-72 lg:overflow-y-auto lg:border-r lg:border-zinc-900/10 lg:px-6 lg:pb-8 lg:pt-4 xl:w-80 lg:dark:border-white/10">
-            <div class="hidden lg:flex">
+          <div class="contents lg:pointer-events-auto lg:block lg:w-72 lg:overflow-y-auto lg:border-r lg:border-zinc-900/10 xl:w-80 lg:dark:border-white/10">
+            <div class="hidden lg:flex sticky top-0 z-20 py-2 px-6 backdrop-blur-sm dark:backdrop-blur bg-white/[var(--bg-opacity-light)] dark:bg-zinc-900/[var(--bg-opacity-dark)]" style="--bg-opacity-light:0.5;--bg-opacity-dark:0.2">
               <%= render 'site_logo' %>
+              <div class="absolute inset-x-0 top-full h-px transition bg-zinc-900/7.5 dark:bg-white/7.5"></div>
             </div>
 
             <%= render 'top_bar' %>

--- a/src/_partials/_navbar.erb
+++ b/src/_partials/_navbar.erb
@@ -1,5 +1,5 @@
-<nav class="pl-5 pt-10 lg:p-0 lg:block max-h-[90%] overflow-y-scroll" :class="{ 'hidden': !nav_open }">
-  <ul role="list">
+<nav class="p-6 pt-8 lg:pt-0 lg:block" :class="{ 'hidden': !nav_open }">
+  <ul role="list" class='max-h-[90svh] overflow-y-scroll lg:max-h-fit lg:overflow-auto'>
     <li class="relative mt-10 ml-0 mr-5 lg:hidden">
       <div id="oba-docs-search-container--mobile"></div>
     </li>

--- a/src/_partials/_top_bar.erb
+++ b/src/_partials/_top_bar.erb
@@ -1,4 +1,4 @@
-<div class="fixed inset-x-0 top-0 z-50 flex h-14 items-center justify-between gap-12 px-4 transition sm:px-6 lg:z-30 lg:px-8  backdrop-blur-sm lg:left-72 xl:left-80 dark:backdrop-blur bg-white/[var(--bg-opacity-light)] dark:bg-zinc-900/[var(--bg-opacity-dark)]" style="--bg-opacity-light:0.5;--bg-opacity-dark:0.2">
+<div class="fixed inset-x-0 top-0 z-50 flex h-14 items-center justify-between gap-12 px-4 transition sm:px-6 lg:z-30 lg:px-8 lg:left-72 xl:left-80 backdrop-blur-sm dark:backdrop-blur bg-white/[var(--bg-opacity-light)] dark:bg-zinc-900/[var(--bg-opacity-dark)]" style="--bg-opacity-light:0.5;--bg-opacity-dark:0.2">
   <div class="absolute inset-x-0 top-full h-px transition bg-zinc-900/7.5 dark:bg-white/7.5"></div>
 
   <div class="hidden lg:block lg:max-w-md lg:flex-auto" id="oba-docs-search-container--desktop">


### PR DESCRIPTION
* Scrollbar should be at outer edge of the navigation pane
* Use `position: sticky` to secure the position of the site logo on larger screens
* Remove green bar adornments from navigation section headings