### PR TITLE
Fixes: GitHub Edit this Page button Hidden on Small Screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",
     "esbuild": "^0.19.2",
-    "glob": "^10.3.3",
+    "glob": "^10.3.10",
     "postcss": "^8.4.29",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-import": "^15.1.0",

--- a/src/_partials/_top_bar.erb
+++ b/src/_partials/_top_bar.erb
@@ -18,7 +18,7 @@
   </div>
 
   <div class="flex items-center gap-5">
-    <nav class="hidden md:block">
+    <nav class="block">
       <div role="list" class="flex items-center gap-8">
         <a class="group" href="https://www.github.com/onebusaway/onebusaway-docs" title="Edit this Page">
           <svg viewBox="0 0 20 20" aria-hidden="true" class="h-5 w-5 fill-zinc-700 dark:fill-zinc-200 transition group-hover:fill-zinc-900 dark:group-hover:fill-zinc-50">

--- a/yarn.lock
+++ b/yarn.lock
@@ -759,7 +759,7 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^10.3.10, glob@^10.3.3:
+glob@^10.3.10:
   version "10.3.10"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.10.tgz#0351ebb809fd187fe421ab96af83d3a70715df4b"
   integrity sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==


### PR DESCRIPTION
fix: #14 issue

When we resize to small screens, the Edit this Page option hides in the navbar which it shouldn't! So, I have fixed the bug and a screenshot for the changes is below:

![image](https://github.com/OneBusAway/onebusaway-docs/assets/62840625/0a253064-03ef-4bf4-bf30-067128cf2348)

Thanks