### PR TITLE
chore: Improved footer icon and text contrast ratio for better readability in dark mode

### DIFF
--- a/src/_partials/_footer.erb
+++ b/src/_partials/_footer.erb
@@ -1,16 +1,16 @@
 <footer class="mx-auto w-full max-w-2xl space-y-10 pb-12 lg:pb-24 lg:max-w-5xl">
   <div class="flex flex-col items-center justify-between gap-5 border-t border-zinc-900/5 pt-8 sm:flex-row dark:border-white/5">
-    <p class="text-xs text-zinc-600 dark:text-zinc-400">&copy; Open Transit Software Foundation.</p>
+    <p class="text-xs text-zinc-600 dark:text-zinc-100">&copy; Open Transit Software Foundation.</p>
     <div class="flex gap-4">
       <a class="group" href="https://www.github.com/onebusaway">
         <span class="sr-only">Follow us on GitHub</span>
-        <svg viewBox="0 0 20 20" aria-hidden="true" class="h-5 w-5 fill-zinc-700 transition group-hover:fill-zinc-900 dark:group-hover:fill-zinc-500">
+        <svg viewBox="0 0 20 20" aria-hidden="true" class="h-5 w-5 fill-zinc-700 dark:fill-zinc-200 transition group-hover:fill-zinc-900 dark:group-hover:fill-zinc-50">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M10 1.667c-4.605 0-8.334 3.823-8.334 8.544 0 3.78 2.385 6.974 5.698 8.106.417.075.573-.182.573-.406 0-.203-.011-.875-.011-1.592-2.093.397-2.635-.522-2.802-1.002-.094-.246-.5-1.005-.854-1.207-.291-.16-.708-.556-.01-.567.656-.01 1.124.62 1.281.876.75 1.292 1.948.93 2.427.705.073-.555.291-.93.531-1.143-1.854-.213-3.791-.95-3.791-4.218 0-.929.322-1.698.854-2.296-.083-.214-.375-1.09.083-2.265 0 0 .698-.224 2.292.876a7.576 7.576 0 0 1 2.083-.288c.709 0 1.417.096 2.084.288 1.593-1.11 2.291-.875 2.291-.875.459 1.174.167 2.05.084 2.263.53.599.854 1.357.854 2.297 0 3.278-1.948 4.005-3.802 4.219.302.266.563.78.563 1.58 0 1.143-.011 2.061-.011 2.35 0 .224.156.491.573.405a8.365 8.365 0 0 0 4.11-3.116 8.707 8.707 0 0 0 1.567-4.99c0-4.721-3.73-8.545-8.334-8.545Z"></path>
         </svg>
       </a>
       <a class="group" href="https://play.google.com/store/apps/details?id=com.joulespersecond.seattlebusbot&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1">
         <span class="sr-only">Find us on the Google Play Store</span>
-        <svg class="h-5 w-5 fill-zinc-700 transition group-hover:fill-zinc-900 dark:group-hover:fill-zinc-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="24px" height="24px" baseProfile="basic">
+        <svg class="h-5 w-5 fill-zinc-700 dark:fill-zinc-200 transition group-hover:fill-zinc-900 dark:group-hover:fill-zinc-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="24px" height="24px" baseProfile="basic">
           <path d="M38,18c-0.732,0-1.409,0.212-2,0.556V17c0-0.552-0.447-1-1-1H13c-0.553,0-1,0.448-1,1v1.556C11.409,18.212,10.732,18,10,18 c-2.206,0-4,1.794-4,4v10c0,2.206,1.794,4,4,4c0.732,0,1.409-0.212,2-0.556V36c0,1.654,1.346,3,3,3v5c0,2.206,1.794,4,4,4 s4-1.794,4-4v-5h2v5c0,2.206,1.794,4,4,4s4-1.794,4-4v-5c1.654,0,3-1.346,3-3v-0.556C36.591,35.788,37.268,36,38,36 c2.206,0,4-1.794,4-4V22C42,19.794,40.206,18,38,18z"/>
           <path d="M19,46c-2.206,0-4-1.794-4-4V32c0-2.206,1.794-4,4-4s4,1.794,4,4v10C23,44.206,21.206,46,19,46z M19,30 c-1.103,0-2,0.897-2,2v10c0,1.103,0.897,2,2,2s2-0.897,2-2V32C21,30.897,20.103,30,19,30z"/>
           <path d="M29,46c-2.206,0-4-1.794-4-4V32c0-2.206,1.794-4,4-4s4,1.794,4,4v10C33,44.206,31.206,46,29,46z M29,30 c-1.103,0-2,0.897-2,2v10c0,1.103,0.897,2,2,2s2-0.897,2-2V32C31,30.897,30.103,30,29,30z"/>
@@ -29,11 +29,15 @@
       </a>
       <a class="group" href="https://apps.apple.com/in/app/onebusaway/id329380089">
         <span class="sr-only">Find us on the App Store</span>
-        <svg class="h-5 w-5 fill-zinc-700 transition group-hover:fill-zinc-900 dark:group-hover:fill-zinc-500" xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 30 30" width="24px" height="24px">    <path d="M25.565,9.785c-0.123,0.077-3.051,1.702-3.051,5.305c0.138,4.109,3.695,5.55,3.756,5.55 c-0.061,0.077-0.537,1.963-1.947,3.94C23.204,26.283,21.962,28,20.076,28c-1.794,0-2.438-1.135-4.508-1.135 c-2.223,0-2.852,1.135-4.554,1.135c-1.886,0-3.22-1.809-4.4-3.496c-1.533-2.208-2.836-5.673-2.882-9 c-0.031-1.763,0.307-3.496,1.165-4.968c1.211-2.055,3.373-3.45,5.734-3.496c1.809-0.061,3.419,1.242,4.523,1.242 c1.058,0,3.036-1.242,5.274-1.242C21.394,7.041,23.97,7.332,25.565,9.785z M15.001,6.688c-0.322-1.61,0.567-3.22,1.395-4.247 c1.058-1.242,2.729-2.085,4.17-2.085c0.092,1.61-0.491,3.189-1.533,4.339C18.098,5.937,16.488,6.872,15.001,6.688z"/></svg>
+        <svg class="h-5 w-5 fill-zinc-700 dark:fill-zinc-200 transition group-hover:fill-zinc-900 dark:group-hover:fill-zinc-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="24px" height="24px">  
+          <path d="M25.565,9.785c-0.123,0.077-3.051,1.702-3.051,5.305c0.138,4.109,3.695,5.55,3.756,5.55 c-0.061,0.077-0.537,1.963-1.947,3.94C23.204,26.283,21.962,28,20.076,28c-1.794,0-2.438-1.135-4.508-1.135 c-2.223,0-2.852,1.135-4.554,1.135c-1.886,0-3.22-1.809-4.4-3.496c-1.533-2.208-2.836-5.673-2.882-9 c-0.031-1.763,0.307-3.496,1.165-4.968c1.211-2.055,3.373-3.45,5.734-3.496c1.809-0.061,3.419,1.242,4.523,1.242 c1.058,0,3.036-1.242,5.274-1.242C21.394,7.041,23.97,7.332,25.565,9.785z M15.001,6.688c-0.322-1.61,0.567-3.22,1.395-4.247 c1.058-1.242,2.729-2.085,4.17-2.085c0.092,1.61-0.491,3.189-1.533,4.339C18.098,5.937,16.488,6.872,15.001,6.688z"/>
+        </svg>
       </a>
       <a class="group" href="https://opentransitsoftwarefoundation.org/blog/">
         <span class="sr-only">Read our Blog</span>
-        <svg class="h-5 w-5 fill-zinc-700 transition group-hover:fill-zinc-900 dark:group-hover:fill-zinc-500" xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 50 50" width="24px" height="24px"><path d="M 9 4 C 6.239 4 4 6.239 4 9 L 4 41 C 4 43.761 6.239 46 9 46 L 41 46 C 43.761 46 46 43.761 46 41 L 46 9 C 46 6.239 43.761 4 41 4 L 9 4 z M 20 12 L 25 12 C 29.42 12 33.033 15.632547 33 20.060547 C 32.991 21.141547 33.919 22 35 22 L 36 22 C 37.105 22 38 22.895 38 24 L 38 30 C 38 34.4 34.4 38 30 38 L 20 38 C 15.6 38 12 34.4 12 30 L 12 25 L 12 20 C 12 15.6 15.6 12 20 12 z M 20 18 C 18.9 18 18 18.9 18 20 C 18 21.1 18.9 22 20 22 L 25 22 C 26.1 22 27 21.1 27 20 C 27 18.9 26.1 18 25 18 L 20 18 z M 20 28 C 18.9 28 18 28.9 18 30 C 18 31.1 18.9 32 20 32 L 30 32 C 31.1 32 32 31.1 32 30 C 32 28.9 31.1 28 30 28 L 20 28 z"/></svg>
+          <svg class="h-5 w-5 fill-zinc-700 dark:fill-zinc-200 transition group-hover:fill-zinc-900 dark:group-hover:fill-zinc-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50" width="24px" height="24px">
+            <path d="M 9 4 C 6.239 4 4 6.239 4 9 L 4 41 C 4 43.761 6.239 46 9 46 L 41 46 C 43.761 46 46 43.761 46 41 L 46 9 C 46 6.239 43.761 4 41 4 L 9 4 z M 20 12 L 25 12 C 29.42 12 33.033 15.632547 33 20.060547 C 32.991 21.141547 33.919 22 35 22 L 36 22 C 37.105 22 38 22.895 38 24 L 38 30 C 38 34.4 34.4 38 30 38 L 20 38 C 15.6 38 12 34.4 12 30 L 12 25 L 12 20 C 12 15.6 15.6 12 20 12 z M 20 18 C 18.9 18 18 18.9 18 20 C 18 21.1 18.9 22 20 22 L 25 22 C 26.1 22 27 21.1 27 20 C 27 18.9 26.1 18 25 18 L 20 18 z M 20 28 C 18.9 28 18 28.9 18 30 C 18 31.1 18.9 32 20 32 L 30 32 C 31.1 32 32 31.1 32 30 C 32 28.9 31.1 28 30 28 L 20 28 z"/>
+          </svg>
       </a>
     </div>
   </div>


### PR DESCRIPTION
#### Description:

Fixed #59

#### Issue fixed:

The issue regarding dim footer icons in dark mode has been successfully resolved. 

#### Changes done:
- [x] Task 1

#### Screenshots/Videos

Before :
![Screenshot from 2024-03-11 21-15-40](https://github.com/OneBusAway/onebusaway-docs/assets/121149738/d7934640-498b-416f-9a4e-46b1ef2b3eb1)

After:
![Screenshot from 2024-03-11 23-12-46](https://github.com/OneBusAway/onebusaway-docs/assets/121149738/5a7541ec-1481-420a-acbe-96ce382429a3)



#### ✅️ By submitting this PR, I have verified the following

- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Tried squashing the commits into one
