### PR TITLE
Fix typo: 'an referenced entity' to 'a referenced entity'

### DIFF
--- a/src/api/where/index.erb
+++ b/src/api/where/index.erb
@@ -124,7 +124,7 @@ of ways.</p>
 
 <p>
   They will always appear in that order, since stops and trips reference routes and routes reference agencies. If you
-  are processing the result stream in order, you should always be able to assume that an referenced entity would already
+  are processing the result stream in order, you should always be able to assume that a referenced entity would already
   have been included in the references section.
 </p>
 


### PR DESCRIPTION
#### Description:

This pull request aims to address a typo error where "an referenced entity" was corrected to "a referenced entity" in "src/api/index.erb". The change improves the clarity and correctness of the content, that is all.

#### Issue fixed:


#### Changes done:
- [x] Corrected a "an referenced entity" to "a referenced entity" in "src/api/index.erb"

#### Screenshots/Videos

![image](https://github.com/OneBusAway/onebusaway-docs/assets/148974966/4391a0b0-d743-4f50-bb6e-60a4ae249561)

#### ✅️ By submitting this PR, I have verified the following

- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [ ] Tried squashing the commits into one
