### PR TITLE
Fixed typos: in src/api/where/elements/trip.md and src/api/where/methods/agencies-with-coverage

### DIFF
--- a/src/api/where/elements/trip.md
+++ b/src/api/where/elements/trip.md
@@ -3,7 +3,7 @@ layout: page
 title: Trip Element
 ---
 
-The `<trip/>` element models trips in OneBusAway.  Trips are directly mapped from entries in the [GTFS trips.txt](http://code.google.com/transit/spec/transit_feed_specification.html#trips_txt___Field_Definitions) file from the GTFS feeds that power an API instance.
+The `<trip/>` element models trips in OneBusAway. Trips are directly mapped from entries in the [GTFS trips.txt](http://code.google.com/transit/spec/transit_feed_specification.html#trips_txt___Field_Definitions) file from the GTFS feeds that power an API instance.
 
 ## Example
 
@@ -19,8 +19,8 @@ The `<trip/>` element models trips in OneBusAway.  Trips are directly mapped fro
 
 ## Details
 
-The fields of the stop element closely match the fields defined for trips in the [GTFS spec](http://code.google.com/transit/spec/transit_feed_specification.html#trips_txt___Field_Definitions).
+The fields of the trip element closely match the fields defined for trips in the [GTFS spec](http://code.google.com/transit/spec/transit_feed_specification.html#trips_txt___Field_Definitions).
 
 A few important details:
 
-* The only fields that are absolutely required are `id`, `routeId`, and `serviceId`.
+- The only fields that are absolutely required are `id`, `routeId`, and `serviceId`.

--- a/src/api/where/methods/agencies-with-coverage.md
+++ b/src/api/where/methods/agencies-with-coverage.md
@@ -1,6 +1,6 @@
 ---
 layout: rest_api
-title: agency-with-coverage Method
+title: agencies-with-coverage Method
 description: Returns a list of all transit agencies currently supported by OneBusAway along with the center of their coverage area.
 sample_request_url: https://api.pugetsound.onebusaway.org/api/where/agencies-with-coverage.json?key=TEST
 example_response_file: agencies-with-coverage.json
@@ -10,6 +10,6 @@ example_response_file: agencies-with-coverage.json
 
 The response has the following fields:
 
-* `agencyId` - an agency id for the agency whose coverage is included.  Should match an [`<agency/>` element](/api/where/elements/agency) referenced in the `<references/>` section.
-* `lat` and `lon` - indicates the center of the agency's coverage area
-* `latSpan` and `lonSpan` - indicate the height (lat) and width (lon) of the coverage bounding box for the agency.
+- `agencyId` - an agency id for the agency whose coverage is included. Should match an [`<agency/>` element](/api/where/elements/agency) referenced in the `<references/>` section.
+- `lat` and `lon` - indicates the center of the agency's coverage area
+- `latSpan` and `lonSpan` - indicate the height (lat) and width (lon) of the coverage bounding box for the agency.


### PR DESCRIPTION
#### Description:

This pull request aims to address a typo error where "the stop element" was corrected to "the trip element" in "src/api/where/elements/trip.md" and,

where "title: agency-with-coverage" was corrected to "title: agencies-with-coverage" in "src/api/where/methods/agencies-with-coverage".

The change improves the clarity and correctness of the content, that is all.

#### Issue fixed:

#### Changes done:
- [x]  Corrected a "the stop element" to "the trip element" in "src/api/where/elements/trip.md"
- [x]  Corrected a "title: agency-with-coverage" to "title: agencies-with-coverage" in "src/api/where/methods/agencies-with-coverage"

#### Screenshots/Videos
![image](https://github.com/OneBusAway/onebusaway-docs/assets/148974966/f31084e8-2c0a-4675-8337-ac550571a071)
![image](https://github.com/OneBusAway/onebusaway-docs/assets/148974966/3688a458-05bf-48a2-bfba-154d784628d7)

#### ✅️ By submitting this PR, I have verified the following

- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [ ] Tried squashing the commits into one
