### PR TITLE
fixed bug of unable to click on the footer links due to the overflow

### DIFF
--- a/src/_layouts/default.erb
+++ b/src/_layouts/default.erb
@@ -32,7 +32,7 @@
               </div>
             </article>
           </main>
-          <div class="hidden sidebar text-xs p-4 2xl:flex flex-col fixed top-24 right-12 w-fit max-w-72 h-full"></div>
+          <div class="hidden sidebar text-xs p-4 2xl:flex flex-col fixed top-24 right-12 w-fit max-w-72 h-fit"></div>
           <%= render "footer", locals: { metadata: site.metadata } %>
         </div>
       </div>


### PR DESCRIPTION


#### Description:

Fixing the minor issue https://github.com/OneBusAway/onebusaway-docs/issues/120 that is unable to click on footer links due to overflow.
The footer links could not be clicked when the hidden sidebar which had height `full`, aligned with the footer links

#### Issue fixed: https://github.com/OneBusAway/onebusaway-docs/issues/120
#### Changes done:
- [x] changed the default.erb file

#### Screenshots/Videos
**Before Change**
![image](https://github.com/OneBusAway/onebusaway-docs/assets/89828000/3686e4a6-a74d-45a4-a2a1-2656656e57ef)

**After Change**
![image](https://github.com/OneBusAway/onebusaway-docs/assets/89828000/9c721a8b-b9d5-4380-bace-1d1e0d94a178)

<!-- Include screenshots or videos if they will help the reviewer understand your changes. -->

#### ✅️ By submitting this PR, I have verified the following

- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Tried squashing the commits into one
