### PR TITLE
Fixed Bug : Missing id to release notes heading

### DIFF
--- a/src/api/where/index.erb
+++ b/src/api/where/index.erb
@@ -7,7 +7,7 @@ title: OneBusAway RESTful API
   that
   powers the OneBusAway website and mobile tools. You can use the api to write cool new apps of your own.</p>
 
-<h2>Release Notes</h2>
+<h2 id="release-notes">Release Notes</h2>
 
 <p>Check out the <a href="/release-notes">Release Notes</a> for details about what&#39;s changed with the API.</p>
 


### PR DESCRIPTION
#### Description:
Fixing the minor issue https://github.com/OneBusAway/onebusaway-docs/issues/123 that there is missing id to **release notes** heading
<!-- Please explain your pull request's purpose -->

#### Issue fixed:
https://github.com/OneBusAway/onebusaway-docs/issues/123
<!-- Link to the issue that your pull request resolves. -->

#### Changes done:
- [x] changed the index.erb file

#### Screenshots/Videos

**The screenshot is after fixing the issue https://github.com/OneBusAway/onebusaway-docs/issues/101 so the release notes heading is visible** 

![image](https://github.com/OneBusAway/onebusaway-docs/assets/89828000/3d3d1ccb-86d7-4140-8d4c-3642c6187617)
<!-- Include screenshots or videos if they will help the reviewer understand your changes. -->

#### ✅️ By submitting this PR, I have verified the following

- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Tried squashing the commits into one
