### PR TITLE
Fixed bug: Header link copying showing paragraph instead of header display

### DIFF
--- a/frontend/styles/index.css
+++ b/frontend/styles/index.css
@@ -90,3 +90,12 @@ pre.highlight {
 }
 
 @tailwind utilities;
+
+/* Prevent headings from getting hidden when directly accessing sections with ids: */
+:target:before {
+    content: "";
+    display: block;
+    height: 80px;
+    margin-top: -80px; 
+}
+


### PR DESCRIPTION
#### Description:

<!-- Please explain your pull request's purpose -->
Fixing the minor issue https://github.com/OneBusAway/onebusaway-docs/issues/101 that is on copying header Link it shows paragraph contents instead of the header display
To solve the issue I have added an empty block when user is using fragment navigation `website_url#id` we will now see the heading and then it's content. Since the navigation bar has height of 56px I chose to use 80px as height for this block.
I edited the index.css file as per PR https://github.com/OneBusAway/onebusaway-docs/pull/122

#### Issue fixed:
https://github.com/OneBusAway/onebusaway-docs/issues/101
<!-- Link to the issue that your pull request resolves. -->

#### Changes done:
- [x] changed the index.css file

#### Screenshots/Videos

**Before Change**
![image](https://github.com/OneBusAway/onebusaway-docs/assets/89828000/5c2bafa7-fbf4-42d0-aeb9-8aac52c98911)

**After Change**
![image](https://github.com/OneBusAway/onebusaway-docs/assets/89828000/1c94e6e5-6c4f-45f0-9b14-b309cc73e3b3)

<!-- Include screenshots or videos if they will help the reviewer understand your changes. -->

#### ✅️ By submitting this PR, I have verified the following

- [x] Checked to see if a similar PR has already been opened 🤔️
- [x] Reviewed the contributing guidelines 🔍️
- [x] Tried squashing the commits into one
