### PR TITLE
updated links to binaries, so that point to Maven Central.

### DIFF
--- a/src/modules/onebusaway-gtfs-modules/current/onebusaway-gtfs-merge-cli.html
+++ b/src/modules/onebusaway-gtfs-modules/current/onebusaway-gtfs-merge-cli.html
@@ -73,8 +73,8 @@
 <p><b>NOTE</b>: This tool is a work in progress! This documentation may not be up-to-date.</p>
 <p>The <code>onebusaway-gtfs-merge-cli</code> command-line application is a simple command-line tool for merging <a class="externalLink" href="https://developers.google.com/transit/gtfs">GTFS</a> feeds. </p></section><section>
 <h2><a name="Getting_the_Application"></a>Getting the Application</h2>
-<p>You can download the application here:</p>
-<p><a class="externalLink" href="https://repo.camsys-apps.com/snapshots/org/onebusaway/onebusaway-gtfs-merge-cli/1.4.16-SNAPSHOT/onebusaway-gtfs-merge-cli-1.4.16-SNAPSHOT.jar">onebusaway-gtfs-merge-cli-1.4.16-SNAPSHOT.jar</a></p></section><section>
+<p>You can download the application Maven Central.</p>
+<p>Go to<a class="externalLink" href="https://repo1.maven.org/maven2/org/onebusaway/onebusaway-gtfs-merge-cli/">https://repo1.maven.org/maven2/org/onebusaway/onebusaway-gtfs-merge-cli/</a>. Select the version you want and get the URL for the largest jar file. An example would be https://repo1.maven.org/maven2/org/onebusaway/onebusaway-gtfs-merge-cli/3.2.2/onebusaway-gtfs-merge-cli-3.2.2.jar</p></section><section>
 <h2><a name="Using_the_Application"></a>Using the Application</h2>
 <p>You'll need a Java 11 runtime installed to run the client. To run the application:</p>
 <div class="source"><pre class="prettyprint">java -jar onebusaway-gtfs-merge-cli.jar [--args] input_gtfs_path_a input_gtfs_path_b ... output_gtfs_path</pre></div>

--- a/src/modules/onebusaway-gtfs-modules/current/onebusaway-gtfs-transformer-cli.html
+++ b/src/modules/onebusaway-gtfs-modules/current/onebusaway-gtfs-transformer-cli.html
@@ -114,8 +114,8 @@
 <ul>
 <li>Java 11 or greater</li></ul></section><section>
 <h2><a name="Getting_the_Application"></a>Getting the Application</h2>
-<p>You can download the application here:</p>
-<p><a class="externalLink" href="https://repo.camsys-apps.com/snapshots/org/onebusaway/onebusaway-gtfs-transformer-cli/1.4.16-SNAPSHOT/onebusaway-gtfs-transformer-cli-1.4.16-SNAPSHOT.jar">onebusaway-gtfs-transformer-cli-1.4.16-SNAPSHOT.jar</a></p></section><section>
+<p>You can download the application Maven Central.</p>
+<p>Go to <a class="externalLink" href="https://repo1.maven.org/maven2/org/onebusaway/onebusaway-gtfs-transformer-cli/">https://repo1.maven.org/maven2/org/onebusaway/onebusaway-gtfs-transformer-cli/</a>and select the largest jar file from the version you would like to use, for example https://repo1.maven.org/maven2/org/onebusaway/onebusaway-gtfs-transformer-cli/2.0.0/onebusaway-gtfs-transformer-cli-2.0.0.jar</p></section><section>
 <h2><a name="Using_the_Application"></a>Using the Application</h2>
 <p>To run the application:</p>
 <div class="source"><pre class="prettyprint">java -jar onebusaway-gtfs-transformer-cli.jar [-args] input_gtfs_path ... output_gtfs_path</pre></div></section><section>


### PR DESCRIPTION
Following our discussions, I've edited the links to point to Maven Central. Leonard Ehrenfried, after becoming maintaner of oba-gtfs-modules gave up the maven-based documentation. It's just markdown files now.