### PR TITLE
feat: Add 'Edit this page' button linking to GitHub issues

### DIFF
--- a/src/_layouts/default.erb
+++ b/src/_layouts/default.erb
@@ -32,6 +32,16 @@
               </div>
             </article>
           </main>
+          <div class="flex flex-col items-center lg:items-start lg:pl-10">
+               <a href="https://github.com/OneBusAway/onebusaway-docs/issues/new" 
+                  target="_blank" 
+                      class="inline-flex items-center text-[#34d399] hover:underline mb-4 lg:order-1 lg:self-start lg:ml-[220px]">
+               <svg class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m1.768-4.95a2.5 2.5 0 00-3.536 0L9 11.828V15h3.172l7.707-7.707a2.5 2.5 0 000-3.536zM19 19H5" />
+               </svg>
+                  Edit this page
+               </a>
+           </div>
           <div class="hidden md:block sidebar text-xs fixed top-24 right-6 w-fit max-w-60 h-fit"></div>
           <%= render "footer", locals: { metadata: site.metadata } %>
         </div>


### PR DESCRIPTION
Fixes: #156 

### Description:
This PR introduces an "Edit this page" button that allows users to quickly navigate to the GitHub issues section to report problems or suggest improvements.

### Screenshots
![Screenshot from 2025-03-21 19-49-45](https://github.com/user-attachments/assets/de5c763f-e25d-48f8-b3dc-1bac05381c50)

![Screenshot from 2025-03-21 20-17-37](https://github.com/user-attachments/assets/78fbae66-9c10-4562-8b79-2f78ead4d0ef)

### Why is this needed?

- Enhances user contribution by providing an easy way to submit issues.
- Improves accessibility and site interactivity.