### PR TITLE
docs: add arrivals-and-departures-for-location endpoint

### DIFF
--- a/src/_data/rest_api.json
+++ b/src/_data/rest_api.json
@@ -12,6 +12,10 @@
             "description": "details about a specific arrival/departure at a stop"
         },
 
+        "arrivals-and-departures-for-location": {
+            "description": "get current arrivals and departures near a location"
+        },
+
         "arrivals-and-departures-for-stop": {
             "description": "get current arrivals and departures for a stop"
         },

--- a/src/api/example_responses/arrivals-and-departures-for-location.json
+++ b/src/api/example_responses/arrivals-and-departures-for-location.json
@@ -1,0 +1,121 @@
+{  
+  "version": 2,  
+  "code": 200,  
+  "text": "OK",  
+  "currentTime": 1270614730908,  
+  "data": {  
+    "references": {  
+      "agencies": [  
+        {  
+          "id": "1",  
+          "name": "Metro Transit",  
+          "url": "http://metro.kingcounty.gov",  
+          "timezone": "America/Los_Angeles",  
+          "lang": "en",  
+          "phone": "(206) 553-3000",  
+          "fareUrl": "http://metro.kingcounty.gov/tops/fares/fare-tickets.htm"  
+        }  
+      ],  
+      "routes": [  
+        {  
+          "id": "1_10",  
+          "shortName": "10",  
+          "longName": "Downtown to U District",  
+          "description": "",  
+          "type": 3,  
+          "url": "http://metro.kingcounty.gov/schedules/010.pdf",  
+          "agencyId": "1",  
+          "color": "003399"  
+        }  
+      ],  
+      "stops": [  
+        {  
+          "id": "1_75403",  
+          "lat": 47.653,  
+          "lon": -122.307,  
+          "name": "University Way NE & NE 45th St",  
+          "code": "75403",  
+          "locationType": 0,  
+          "wheelchairBoarding": 1,  
+          "routeIds": ["1_10", "1_49", "1_65"]  
+        }  
+      ],  
+      "trips": [  
+        {  
+          "id": "1_12345",  
+          "routeId": "1_10",  
+          "serviceId": "1_Weekday",  
+          "tripHeadsign": "U District",  
+          "tripShortName": "",  
+          "directionId": 0,  
+          "blockId": "1_100",  
+          "shapeId": "1_10_0",  
+          "wheelchairAccessible": 1  
+        }  
+      ],  
+      "situations": []  
+    },  
+    "entry": {  
+      "class": "stopsWithArrivalsAndDepartures",  
+      "stopIds": ["1_75403"],  
+      "arrivalsAndDepartures": [  
+        {  
+          "tripId": "1_12345",  
+          "serviceDate": 1270614730000,  
+          "vehicleId": "1_4001",  
+          "stopId": "1_75403",  
+          "stopSequence": 15,  
+          "blockTripSequence": 0,  
+          "totalStopsInTrip": 30,  
+          "routeId": "1_10",  
+          "routeShortName": "10",  
+          "routeLongName": "Downtown to U District",  
+          "tripHeadsign": "U District",  
+          "arrivalEnabled": true,  
+          "departureEnabled": true,  
+          "scheduledArrivalTime": 1270614730000,  
+          "scheduledDepartureTime": 1270614730000,  
+          "predictedArrivalTime": 1270614750000,  
+          "predictedDepartureTime": 1270614750000,  
+          "predicted": true,  
+          "distanceFromStop": 150.5,  
+          "numberOfStopsAway": 2,  
+          "historicalOccupancy": 0,  
+          "occupancyStatus": null,  
+          "status": "default",  
+          "tripStatus": {  
+            "activeTripId": "1_12345",  
+            "blockId": "1_100",  
+            "closestStop": "1_75402",  
+            "closestStopTimeOffset": 30,  
+            "distanceAlongBlock": 5000.0,  
+            "lastUpdateTime": 1270614720000,  
+            "nextStop": "1_75403",  
+            "nextStopTimeOffset": 60,  
+            "orientation": 45.0,  
+            "phase": "IN_PROGRESS",  
+            "position": {  
+              "lat": 47.6525,  
+              "lon": -122.3065  
+            },  
+            "predicted": true,  
+            "scheduleDeviation": 120,  
+            "serviceDate": 1270614730000,  
+            "situationIds": [],  
+            "totalDistanceAlongBlock": 10000.0,  
+            "vehicleId": "1_4001"  
+          },  
+          "situationIds": []  
+        }  
+      ],  
+      "nearbyStopIds": [  
+        {  
+          "stopId": "1_75414",  
+          "distanceFromQuery": 63.30975615515593  
+          }  
+      ],  
+      "situationIds": [],  
+      "limitExceeded": false  
+    }  
+  }  
+}

--- a/src/api/where/elements/arrival-and-departure.md
+++ b/src/api/where/elements/arrival-and-departure.md
@@ -7,6 +7,7 @@ The `<arrivalAndDeparture/>` element captures information about the arrival and 
 
 * [arrivals-and-departures-for-stop](/api/where/methods/arrivals-and-departures-for-stop)
 * [arrival-and-departure-for-stop](/api/where/methods/arrival-and-departure-for-stop)
+* [arrivals-and-departures-for-location](/api/where/methods/arrivals-and-departures-for-location)
 
 ## Example
 

--- a/src/api/where/methods/arrivals-and-departures-for-location.md
+++ b/src/api/where/methods/arrivals-and-departures-for-location.md
@@ -1,0 +1,30 @@
+---
+layout: rest_api
+title: arrivals-and-departures-for-location Method
+description: Get current arrivals and departures for a given location
+sample_request_url: https://api.pugetsound.onebusaway.org/api/where/arrivals-and-departures-for-location.json?key=TEST&lat=47.653&lon=-122.307&radius=100
+example_response_file: arrivals-and-departures-for-location.json
+---
+
+Get current arrivals and departures for stops identified by a specific location (using a bounding box or a radius).
+
+## Request Parameters
+
+* **lat** (Required) - The latitude coordinate of the search center.
+* **lon** (Required) - The longitude coordinate of the search center.
+* **radius** (Optional) - The search radius in meters.
+* **latSpan / lonSpan** (Optional) - Set the limits of the search bounding box. Used as an alternative to `radius`.
+* **time** (Optional) - By default, the method returns the status of the system right now. However, the system can also be queried at a specific time (in milliseconds since the Unix epoch). This can be useful for testing.
+* **minutesBefore** (Optional) - Include arrivals and departures this many minutes before the query time. Defaults to 5.
+* **minutesAfter** (Optional) - Include arrivals and departures this many minutes after the query time. Defaults to 35.
+* **maxCount** (Optional) - The maximum size of the list of nearby stops and arrivals to return. Defaults to 250, can be up to 1000.
+* **routeType** (Optional) - A comma-delimited list of GTFS routeTypes to filter by.
+* **emptyReturnsNotFound** (Optional) - A boolean flag. If set to `true`, the API will return a `404 Not Found` error instead of a `200 OK` with an empty result when no stops or arrivals are found in the specified location.
+
+## Response
+
+The response contains a list of `arrivalsAndDepartures` matching the specified location parameters. 
+
+The `nearbyStopIds` list is designed to capture stops that are very close by (like across the street) for quick navigation. This is sorted by distance and truncated to `maxCount`. 
+
+Trips will not show up in the results if their schedule relationship is skipped or if there is no active service for the given time window.


### PR DESCRIPTION
### Description
This PR adds the missing documentation for the `arrivals-and-departures-for-location` API endpoint.

### Changes Included:
* **New Method Page:** Created `arrivals-and-departures-for-location.md` containing a complete list of all supported query parameters (including `latSpan`, `routeType`, `emptyReturnsNotFound`, etc.).
* **Sample Response:** Added a detailed JSON payload matching the legacy Java server output to clarify the nested `entry` and `nearbyStopIds` structure.
* **Navigation:** Registered the endpoint in `rest_api.json` so it appears in the side navigation menu.
* **Element Link:** Added a reference to this new endpoint in `arrival-and-departure.md` since it returns this element as part of its payload.

## Local Preview (Screenshots)
Here is how the new endpoint and the updated elements page look like when running locally:
<img width="1912" height="967" alt="image" src="https://github.com/user-attachments/assets/f722975b-4f66-4b06-a884-cc24751d65cf" />

@aaronbrethorst 
closes: #165 
