### PR TITLE
fix: close unclosed code fence in README Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ cd onebusaway-docs
 bundle install
 yarn install
 bin/bridgetown start
+```
 
 ## Improve the Documentation
 


### PR DESCRIPTION
What
Added missing closing code fence (```) to the Quick Start section.

Why
The unclosed code block caused the entire README to render as a code block in Markdown, making the contribution guide and other sections unreadable.

How to verify
View the README on GitHub — all sections below Quick Start should now render as normal Markdown.