### PR TITLE
docs: improve quickstart guide with Java version, transit data links,…

### DIFF
--- a/src/guides/quickstart-guide.md
+++ b/src/guides/quickstart-guide.md
@@ -53,6 +53,8 @@ Running OneBusAway is a two-step process:
 
 You can perform these two steps either using our simple GUI configuration tool or from the command-line.
 
+**Note:** Replace `onebusaway-quickstart-assembly.war` in the commands below with the actual filename you downloaded, for example `onebusaway-quickstart-assembly-1.1.19-api-webapp.war`.
+
 ## Using the GUI
 
 Simply double-click the downloaded `.war` file and follow the on-screen steps.

--- a/src/guides/quickstart-guide.md
+++ b/src/guides/quickstart-guide.md
@@ -3,18 +3,9 @@ title: Quickstart Guide
 layout: page
 ---
 
-**NOTE**: this guide is out of date and should not be relied upon as a good example of how to set up a new OBA server. Instead, we recommend using our official Docker image to launch an OBA server quickly and easily. You can find [the code repository for our Docker image on GitHub](https://github.com/onebusAway/onebusaway-docker) and the latest built images on [Docker Hub](https://hub.docker.com/r/opentransitsoftwarefoundation/onebusaway-api-webapp).
+**NOTE**: For new users, we recommend starting with our [Render.com Deployment Guide](/guides/deployment/render), which uses our official Docker image and is actively maintained. The guide below covers the legacy WAR-based approach and can still be useful for evaluation or custom deployments.
 
-Also, to simplify testing your new server on our mobile apps we are adding support for custom URL schemes on our iOS and Android apps that will add your custom region to the app. Make sure the tasks are complete and that you're using an up-to-date app version to ensure this feature works.
-
-* [Android task](https://github.com/OneBusAway/onebusaway-android/issues/1179)
-* [iOS task](https://github.com/OneBusAway/onebusaway-ios/issues/719)
-
-Example URL for a Davis, CA (Unitrans) server:
-
-<a href="onebusaway://add-region?name=Unitrans&oba-url=https%3A%2F%2Fonebusaway-api-server-7mb1.onrender.com%2Fonebusaway-api-webapp">onebusaway://add-region?name=Unitrans&oba-url=https%3A%2F%2Fonebusaway-api-server-7mb1.onrender.com%2Fonebusaway-api-webapp</a>
-
-------------
+---
 
 We have a quick-start distribution designed to get you quickly up and running with the OneBusAway application suite.
 This can be a good way to evaluate OneBusAway without getting bogged down in more complex deployment scenarios.
@@ -28,25 +19,30 @@ that powers a number of mobile applications.  For more information on these feat
 
 ## Prerequisites
 
-At a bare minimum, you'll need [Java](http://www.java.com/en/) installed on your system.  You will also need the
-following:
+You will need Java installed on your system.  Specifically, you'll need **Java 11 or later** (Java 17 LTS is recommended).
+You can download a free JDK from [Adoptium](https://adoptium.net/temurin/releases/?version=17).  After installing, verify the installation by running `java -version` — you should see something like `openjdk version "17.x.x"`.
+
+For large agency GTFS feeds, you may need more memory than the default. The commands below use `-Xmx1G` (1GB) — increase this if you encounter out-of-memory errors.
 
 ## Transit Data
 
 You will need transit data to power your OneBusAway installation.  At minimum, you'll need
 [GTFS](https://developers.google.com/transit/gtfs/) static schedule data feed for your target
-transit agency.  Optionally, but ideally, you will also need real-time data for your transit agency.  OneBusAway
+transit agency.  This is a commonly missed step — OneBusAway cannot run without transit data.
+
+To find a GTFS feed for your transit agency, browse the [Mobility Database](https://mobilitydatabase.org/), which provides a searchable catalog of transit feeds worldwide.  For testing and evaluation, [BART's GTFS feed](https://www.bart.gov/schedules/developers/gtfs) is well-maintained and a good size for getting started.
+
+Optionally, but ideally, you will also need real-time data for your transit agency.  OneBusAway
 supports real-time data for delays, service alerts, and vehicle positions in the
 [GTFS-realtime](https://developers.google.com/transit/gtfs-realtime) format or the [SIRI](https://www.siri-cen.eu) format.
 
 ## Download a Quickstart Bundle
 
-You need to download one of the quickstart bundles.  Pick a bundle based on what features you are interested in:
+Download one of the quickstart `.war` files from our
+[Downloads page](/downloads):
 
 * The full webapp: `onebusaway-quickstart-assembly-webapp.war` - Includes the [REST API](/api/where) and [the web interfaces](/features/web).
 * The API-only webapp: `onebusaway-quickstart-assembly-api-webapp.war` - Includes just the [REST API](/api/where).
-
-Find links to both of these WAR files on our [Downloads page](/downloads).
 
 ## Let's Go!
 
@@ -59,11 +55,10 @@ You can perform these two steps either using our simple GUI configuration tool o
 
 ## Using the GUI
 
-We provide a simple wizard to help you configure and run the OneBusAway quick-start application.  Simply double-click
-the downloaded quick-start war file.  Follow the steps and you'll be up and running in no time.
+Simply double-click the downloaded `.war` file and follow the on-screen steps.
 
-**NOTE:** You may need to run the OneBusAway quick-start GUI from the command-line if you want to pass additional
-options to `java`, like specifying more memory or server optimization:
+**NOTE:** You may need to launch from the command-line to pass extra options
+to `java`, such as more memory:
 
 ~~~
 java -Xmx1G -server -jar onebusaway-quickstart-assembly.war
@@ -91,3 +86,7 @@ To see more options for configuring the build and the webapp, including adding r
 ~~~
 java -jar onebusaway-quickstart-assembly.war -help
 ~~~
+
+## Need Help?
+
+If you run into issues, check out our [Troubleshooting Guide](/guides/troubleshooting-guide).  For more information on deployment, see the [Render.com Deployment Guide](/guides/deployment/render).  You can also reach out on our [community Slack](https://onebusaway.slack.com), report issues on [GitHub](https://github.com/OneBusAway/onebusaway-docs/issues), or check out the [onebusaway-docker repository](https://github.com/OneBusAway/onebusaway-docker).


### PR DESCRIPTION
Fixes #95

## Changes
- Replaced vague "out of date" banner with a clearer note directing new users to the Render.com deployment guide
- Specified Java 11/17 as the recommended version with a download link to Adoptium and a verification command
- Added a warning that transit data is a commonly missed step, with links to the Mobility Database and BART's GTFS feed as a test option
- Added a "Need Help?" section with links to the troubleshooting guide, Slack, GitHub issues, and the Docker repository