### PR TITLE
docs: add section on configuring multiple GTFS-realtime feeds

### DIFF
--- a/src/guides/realtime-configuration-guide.md
+++ b/src/guides/realtime-configuration-guide.md
@@ -39,6 +39,37 @@ GTFS-realtime data-sources from different agencies in the same system.
 You must provide both a `TripUpdates` feed and a `VehiclePositions` feed in order for OneBusAway to report vehicle positions.
 Without a `TripUpdates` feed OneBusAway will discard the vehicle positions.
 
+## Multiple GTFS-realtime Feeds
+
+If you are running a multi-agency instance of OneBusAway, you can configure multiple `GtfsRealtimeSource` beans in
+your `data-sources.xml` file — one for each agency.  Each bean should specify its own `agencyId` so that OneBusAway
+can correctly match incoming real-time data to the right agency's static schedule data.
+
+Here is an example with two agencies, based on a real-world deployment combining HART and PSTA in the Tampa Bay area:
+
+~~~
+<!-- Agency 1: HART -->
+<bean class="org.onebusaway.transit_data_federation.impl.realtime.gtfs_realtime.GtfsRealtimeSource">
+  <property name="tripUpdatesUrl" value="http://realtime.prod.obahart.org:8088/trip-updates" />
+  <property name="vehiclePositionsUrl" value="http://realtime.prod.obahart.org:8088/vehicle-positions" />
+  <property name="refreshInterval" value="15" />
+  <property name="agencyId" value="Hillsborough Area Regional Transit" />
+</bean>
+
+<!-- Agency 2: PSTA -->
+<bean class="org.onebusaway.transit_data_federation.impl.realtime.gtfs_realtime.GtfsRealtimeSource">
+  <property name="tripUpdatesUrl" value="http://ridepsta.net/gtfsrt/trips" />
+  <property name="vehiclePositionsUrl" value="http://ridepsta.net/gtfsrt/vehicles" />
+  <property name="alertsUrl" value="http://ridepsta.net/gtfsrt/alerts" />
+  <property name="refreshInterval" value="15" />
+  <property name="agencyId" value="PSTA" />
+</bean>
+~~~
+
+If the two agencies share any stops, you will want to merge them so that riders see arrivals from both agencies on a
+single stop page.  See the [transit data bundle guide](/guides/transit-data-bundle-guide) for more information on
+stop merging.
+
 ## SIRI VM
 
 We support [SIRI](https://www.siri-cen.eu) out of the box, including support for vehicle monitoring (VM) and situation

--- a/src/guides/realtime-configuration-guide.md
+++ b/src/guides/realtime-configuration-guide.md
@@ -44,6 +44,8 @@ Without a `TripUpdates` feed OneBusAway will discard the vehicle positions.
 If you are running a multi-agency instance of OneBusAway, you can configure multiple `GtfsRealtimeSource` beans in
 your `data-sources.xml` file — one for each agency.  Each bean should specify its own `agencyId` so that OneBusAway
 can correctly match incoming real-time data to the right agency's static schedule data.
+The `agencyId` value must match the `agency_id` field in your bundled GTFS data exactly — you can find this value
+in the `agency.txt` file of your GTFS feed.
 
 Here is an example with two agencies, based on a real-world deployment combining HART and PSTA in the Tampa Bay area:
 
@@ -53,7 +55,7 @@ Here is an example with two agencies, based on a real-world deployment combining
   <property name="tripUpdatesUrl" value="http://realtime.prod.obahart.org:8088/trip-updates" />
   <property name="vehiclePositionsUrl" value="http://realtime.prod.obahart.org:8088/vehicle-positions" />
   <property name="refreshInterval" value="15" />
-  <property name="agencyId" value="Hillsborough Area Regional Transit" />
+  <property name="agencyId" value="HART" />
 </bean>
 
 <!-- Agency 2: PSTA -->


### PR DESCRIPTION
Closes #144

## Changes
- Added a new "Multiple GTFS-realtime Feeds" section to the realtime configuration guide
- Shows how to configure multiple GtfsRealtimeSource beans, one per agency, each with its own agencyId
- Includes a real-world example based on the HART + PSTA Tampa Bay deployment from the community discussion
- Added a note about stop merging for agencies that share stops, with a link to the transit data bundle guide