### PR TITLE
docs: update v2 config deploy guide for Ubuntu 22.04, JDK 11, Tomcat …

### DIFF
--- a/src/guides/wiki/oba-2x-config-deploy-guide.md
+++ b/src/guides/wiki/oba-2x-config-deploy-guide.md
@@ -134,9 +134,12 @@ Next we need the MySQL Connector Java Library. This will allow OneBusAway to use
 
 ## Create the MySQL Database
 
-Now we are going to create the database that OneBusAway will use to store user and API data. To do this run the following command:
+Now we are going to create the database that OneBusAway will use to store user and API data. To do this run the following commands:
 
-    mysql -p -e "CREATE DATABASE oba; GRANT ALL PRIVILEGES ON oba.* TO 'oba'@'localhost' IDENTIFIED BY 'newPassword';"
+    mysql -p -e "CREATE DATABASE oba;"
+    mysql -p -e "CREATE USER 'oba'@'localhost' IDENTIFIED BY 'newPassword';"
+    mysql -p -e "GRANT ALL PRIVILEGES ON oba.* TO 'oba'@'localhost';"
+    mysql -p -e "FLUSH PRIVILEGES;"
 
 In the above commands, replace **newPassword** with something secure. This will be the password for the MySQL user oba who will only have access to the database oba. When prompted for a password, enter the root password you set earlier.
 

--- a/src/guides/wiki/oba-2x-config-deploy-guide.md
+++ b/src/guides/wiki/oba-2x-config-deploy-guide.md
@@ -273,7 +273,7 @@ In the above XML code you will need to replace newPassword in the SQL settings w
       </bean>
     </beans>
 
-Take note of the second-to-last bean in the XML. This is an API key for testing purposes. It is very important to either change the key or remove it entirely before making your OBA installation live. If you want to allow users to connect to your OBA instance with the various OBA apps, you must include additional beans that have the default API keys for the respective app. You can get the code for these beans from this file before you replace its contents.
+Take note of the last bean in the XML. This is an API key for testing purposes. It is very important to either change the key or remove it entirely before making your OBA installation live. If you want to allow users to connect to your OBA instance with the various OBA apps, you must include additional beans that have the default API keys for the respective app. You can get the code for these beans from this file before you replace its contents.
 
 Also, in the above XML code you will need to replace newPassword in the SQL settings with the password you chose for the oba user.
 

--- a/src/guides/wiki/oba-2x-config-deploy-guide.md
+++ b/src/guides/wiki/oba-2x-config-deploy-guide.md
@@ -105,7 +105,7 @@ Next we need to download the GTFS Data from the transit agency. With this data w
     cd /oba/gtfs
     wget http://transitagency.example.com/gtfs.zip
 
-In the proceeding command, replace **http://transitagency.example.com/gtfs.zip** with the full URL of the GTFS from your respective transit agency. Take note of the actual file name being downloaded, as it will be needed later.
+In the preceding command, replace **http://transitagency.example.com/gtfs.zip** with the full URL of the GTFS from your respective transit agency. Take note of the actual file name being downloaded, as it will be needed later.
 
 ## Build the Transit Data Bundle
 

--- a/src/guides/wiki/oba-2x-config-deploy-guide.md
+++ b/src/guides/wiki/oba-2x-config-deploy-guide.md
@@ -112,7 +112,7 @@ In the preceding command, replace **http://transitagency.example.com/gtfs.zip** 
 Now it is time to build the Transit Data Bundle that OneBusAway will use to display route and schedule information. To do this run the following command:
 
     cd /oba/gtfs
-    java -jar -Xss4m -Xmx1g \
+    java -Xss4m -Xmx1g -jar \
       /oba/onebusaway-transit-data-federation-builder-2.5.12-cs-withAllDependencies.jar \
       /oba/gtfs/gtfs.zip \
       /oba/gtfs

--- a/src/guides/wiki/oba-2x-config-deploy-guide.md
+++ b/src/guides/wiki/oba-2x-config-deploy-guide.md
@@ -49,13 +49,13 @@ The MySQL Server is used to store OneBusAway user data and API keys. To install 
 
     apt-get install mysql-server
 
-After installation, run the following to set the root password manually, as newer versions of MySQL no longer prompt you to set one during install:
+After installation, run the following to set the root password manually while keeping MySQL's default authentication plugin:
 
     mysql -u root
 
 Once in the MySQL shell, run:
 
-    ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'your_root_password';
+    ALTER USER 'root'@'localhost' IDENTIFIED BY 'your_root_password';
     FLUSH PRIVILEGES;
     EXIT;
 

--- a/src/guides/wiki/oba-2x-config-deploy-guide.md
+++ b/src/guides/wiki/oba-2x-config-deploy-guide.md
@@ -3,87 +3,102 @@ title: Configuration and Deployment Guide for v2.x
 layout: page
 ---
 
-<div class='bg-blue-50 border-blue-500 dark:bg-slate-800 p-4 rounded-md'>
-    <div><strong>Original location</strong>: <a href='https://github.com/OneBusAway/onebusaway/wiki/Configuration-and-Deployment-Guide-for-v2.x'>https://github.com/OneBusAway/onebusaway/wiki/Configuration-and-Deployment-Guide-for-v2.x</a></div>
-    <div><strong>Last updated</strong>: October 2021</div>
-</div>
+**NOTE**: Unless you have a specific reason to set up OneBusAway manually, we strongly recommend using the [official Docker image](/guides/deployment) instead. It is easier to install, maintain, and is actively supported.
 
 This guide is designed to provide a comprehensive deployment method for users who wish to set up a simple OneBusAway application with minimal configurations. It is primarily intended for use cases that would need to be more permanent than just using the quick start version of OneBusAway. Unlike quick start, this solution boots with the server automatically with no additional configuration required.
 
 ## Note on Software Versions
 
-When using this guide, be certain to use the exact same versions of all software mentioned here. Any discrepancies between this guide and your actual installation will more than likely result in complicated errors and, ultimately failure. Follow the instructions exactly and there should be no issues.
+When using this guide, be certain to use the exact same versions of all software mentioned here. Any discrepancies between this guide and your actual installation will more than likely result in complicated errors and, ultimately, failure. Follow the instructions exactly and there should be no issues.
 
 ## Server Minimum Requirements
 
 The minimum system requirements for your server depend on the size of the transit agency that the deployment is for. Failure to select a server with sufficient processing power and, more importantly, memory, will result in the Tomcat service, or the server itself needing a reboot several times a day. This guide is written for a small to medium sized municipal transit agency, with about 64 routes, 317 vehicles and 2414 stops. For this deployment I am using a virtual server with 2.0 GHz of processor power and 2048 MB of memory.
 
 ## Server Operating System
-This guide assumes the end user already knows how to set up a server (virtual or dedicated) using the Debian 9 operating system. We need to start with a clean installation of Debian 9 with no extra anything, not even the Debian desktop environment.
 
-When setting up Debian 9 using the installer, be certain not to install any additional components except for the SSH server and standard system utilities. You can probably get away with including more on the server but this guide is written with a clean, lightweight server environment in mind and making your server the same will help insure success. Also, the less that is running on the server, the more resources available for OneBusAway.
+This guide assumes the end user already knows how to set up a server (virtual or dedicated) using the Ubuntu 22.04 LTS operating system. We need to start with a clean installation of Ubuntu 22.04 with no extra anything, not even the desktop environment.
+
+When setting up Ubuntu 22.04 using the installer, be certain not to install any additional components except for the SSH server and standard system utilities. You can likely get away with including more on the server but this guide is written with a clean, lightweight server environment in mind and making your server the same will help ensure success. Also, the less that is running on the server, the more resources available for OneBusAway.
+
 You will need access to the root user to follow this guide. All commands are executed as the root user.
 
 ## Installing Required Software
-Before performing these steps, make sure Debian's Software Repository is up to date. To do this, run this command.
+
+Before performing these steps, make sure Ubuntu's software repository is up to date. To do this, run this command:
+
 `apt-get update`
 
-Using Debian 9, the following software must be installed:
-### OpenJDK Runtime Environment 8
-This is the open source version of the Java 8 JDK Runtime Environment. To install it run the following command:
+Using Ubuntu 22.04, the following software must be installed:
 
-`apt-get install openjdk-8-jdk`
+### OpenJDK 11
 
-### Tomcat 8
+This is the open source version of the Java 11 JDK. To install it run the following command:
+
+`apt-get install openjdk-11-jdk`
+
+### Tomcat 9
+
 This software is used to serve the OneBusAway web application. To install it run the following command:
 
-`apt-get install tomcat8`
+`apt-get install tomcat9`
 
 ### MySQL Server
-The MySQL Server is used to store OneBusAway user data and API keys. Since Debian no longer has MySQL in its application repository as of Debian 9, it is a little more complicated to install. To install it, run the following commands:
 
-    cd ~
-    wget https://dev.mysql.com/get/mysql-apt-config_0.8.6-1_all.deb
-    apt-get install gdebi-core
-    gdebi mysql-apt-config_0.8.6-1_all.deb
-    apt-get update
+The MySQL Server is used to store OneBusAway user data and API keys. To install it, run the following commands:
+
     apt-get install mysql-server
 
-During the install process, you will be prompted to create a password for the root MySQL user. Make sure to take note of the password you set because it will be needed later.
+After installation, run the following to set the root password manually, as newer versions of MySQL no longer prompt you to set one during install:
+
+    mysql -u root
+
+Once in the MySQL shell, run:
+
+    ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'your_root_password';
+    FLUSH PRIVILEGES;
+    EXIT;
+
+Replace **your_root_password** with a secure password of your choice. Take note of this password as it will be needed later.
 
 ## Configure Tomcat to use More Memory
-By default Tomcat uses a very small amount of memory. Usually this is not enough memory to run OneBusAway. To fix this run the following commands:
 
-`nano /etc/default/tomcat8`
+By default Tomcat uses a very small amount of memory. Usually this is not enough memory to run OneBusAway. To fix this run the following command:
 
-Change the line that says `-Djava.awt.headless=true -XX:+UseConcMarkSweepGC` to `JAVA_OPTS="-Djava.awt.headless=true -Xss4m -Xmx2g -XX:+UseConcMarkSweepGC"`
+`nano /etc/default/tomcat9`
+
+Change the line that says `-Djava.awt.headless=true` to `JAVA_OPTS="-Djava.awt.headless=true -Xss4m -Xmx2g"`
 
 Note the **Xmx** variable. This variable is used to indicate to Tomcat exactly how much memory it is allowed to use. You may need to tweak this variable dependent on the size of the transit agency.
-Also note the **Xss** variable. This variable is used to indciate to Tomcat the maximum stack size it is allowed to have. You may also need to tweak this variable dependent on the size of the transit agency.
+Also note the **Xss** variable. This variable is used to indicate to Tomcat the maximum stack size it is allowed to have. You may also need to tweak this variable dependent on the size of the transit agency.
 
 ## Acquiring the Binaries
+
 Now that all of the required supporting software is installed, we must either download the binaries from OneBusAway or we must compile and build the binaries from the source code.
 
 ### Compile and Build the Binaries
-It is recommended that you **do not** attempt to compile and download the binaries if you are not going to make any changes to OneBusAway's source code. If you just want to install it, skip this and proceed to the Download the Binaries step.
+
+It is recommended that you **do not** attempt to compile and build the binaries if you are not going to make any changes to OneBusAway's source code. If you just want to install it, skip this and proceed to the Download the Binaries step.
 
 If you are keen to make changes to the source code of OBA, please see the [Enterprise Webapp Configuration](https://github.com/OneBusAway/onebusaway-application-modules/wiki/Enterprise-Webapp-Configuration).
 
 **Please note:** If you build the binaries instead of downloading them, the paths in the remaining commands in this guide may vary from the actual locations of the built binaries. You will need to adjust the paths in the commands accordingly.
 
 ### Download the Binaries
-You can download pre-compiled binaries for OneBusAway from: http://nexus.onebusaway.org/nexus/content/groups/public/org/onebusaway/. If you wish to browse the repository to hand pick the version you want to use, make sure to download the *onebusaway-transit-data-federation-webapp*, *onebusaway-api-webapp* and *onebusaway-enterprise-acta-webapp* files that resulted from the same version build. This can be determined based on the name of the directory which reflects the respective version name of the build (e.g. 2.0.0-SNAPSHOT) that each individual jar or war files are located in. **Note:** Some versions of OBA are not compatible with Tomcat 8 and Java 8, you may need to use an older OS and older version of Java.
 
-If you do not care about versions, go for the latest by downloading them with the following commands:
+You can download pre-compiled binaries for OneBusAway from the [Downloads](/downloads) page.  Make sure to download the *onebusaway-transit-data-federation-webapp*, *onebusaway-api-webapp* and *onebusaway-enterprise-acta-webapp* files from the same version build.  **Note:** Some versions of OBA may not be compatible with all versions of Tomcat and Java. If you encounter issues, check the release notes for the version you are using.
+
+To download the current version (`2.5.12-cs`), run the following commands.  If a newer version is available on the [Downloads](/downloads) page, replace `2.5.12-cs` with the latest version number throughout this guide.
 
     mkdir /oba
     cd /oba
-    wget https://repo.camsys-apps.com/releases/org/onebusaway/onebusaway-transit-data-federation-builder/2.0.0/onebusaway-transit-data-federation-builder-2.0.0-withAllDependencies.jar
-    wget https://repo.camsys-apps.com/releases/org/onebusaway/onebusaway-transit-data-federation-webapp/2.0.0/onebusaway-transit-data-federation-webapp-2.0.0.war
-    wget https://repo.camsys-apps.com/releases/org/onebusaway/onebusaway-api-webapp/2.0.0/onebusaway-api-webapp-2.0.0.war
-    wget https://repo.camsys-apps.com/releases/org/onebusaway/onebusaway-enterprise-acta-webapp/2.0.0/onebusaway-enterprise-acta-webapp-2.0.0.war
+    wget https://repo.camsys-apps.com/releases/org/onebusaway/onebusaway-transit-data-federation-builder/2.5.12-cs/onebusaway-transit-data-federation-builder-2.5.12-cs-withAllDependencies.jar
+    wget https://repo.camsys-apps.com/releases/org/onebusaway/onebusaway-transit-data-federation-webapp/2.5.12-cs/onebusaway-transit-data-federation-webapp-2.5.12-cs.war
+    wget https://repo.camsys-apps.com/releases/org/onebusaway/onebusaway-api-webapp/2.5.12-cs/onebusaway-api-webapp-2.5.12-cs.war
+    wget https://repo.camsys-apps.com/releases/org/onebusaway/onebusaway-enterprise-acta-webapp/2.5.12-cs/onebusaway-enterprise-acta-webapp-2.5.12-cs.war
 
 ## Download the Transit GTFS Data From the Transit Agency
+
 Next we need to download the GTFS Data from the transit agency. With this data we can build the Transit Data Bundle that OneBusAway will use as a data source. To do this run the following commands in sequence:
 
     mkdir /oba/gtfs
@@ -93,65 +108,69 @@ Next we need to download the GTFS Data from the transit agency. With this data w
 In the proceeding command, replace **http://transitagency.example.com/gtfs.zip** with the full URL of the GTFS from your respective transit agency. Take note of the actual file name being downloaded, as it will be needed later.
 
 ## Build the Transit Data Bundle
+
 Now it is time to build the Transit Data Bundle that OneBusAway will use to display route and schedule information. To do this run the following command:
 
     cd /oba/gtfs
     java -jar -Xss4m -Xmx1g \
-      /oba/onebusaway-transit-data-federation-builder-2.0.0-20180106.064533-47-withAllDependencies.jar \
+      /oba/onebusaway-transit-data-federation-builder-2.5.12-cs-withAllDependencies.jar \
       /oba/gtfs/gtfs.zip \
       /oba/gtfs
 
-In the above command, replace **gtfs.zip** with the name of the GTFS data file that was downloaded earlier. The extension of the file should end with **.zip**. This process will take a while to run. When it is complete you should see “Shutting down EHCache CacheManager” with no major errors before it.
+In the above command, replace **gtfs.zip** with the name of the GTFS data file that was downloaded earlier. The extension of the file should end with **.zip**. This process will take a while to run. When it is complete you should see "Shutting down EHCache CacheManager" with no major errors before it.
 
 When executing this particular script, you must run it from within the /oba/gtfs directory because it puts the built files in the current active directory of the command line. To avoid this problem, be certain to execute all of the commands in this step.
 
 ## Download the MySQL Connector Java Library
-Next we need the MySQL Connector Java Library. This will allow OneBusAway to use the MySQL database. You can download the library from [https://dev.mysql.com/downloads/connector/j/](https://dev.mysql.com/downloads/connector/j/). To do this, run the following commands in sequence:
+
+Next we need the MySQL Connector Java Library. This will allow OneBusAway to use the MySQL database. To do this, run the following commands in sequence:
 
     cd /oba
-    wget https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.46.tar.gz
-    tar -zxvf mysql-connector-java-5.1.46.tar.gz
-    mv mysql-connector-java-5.1.46/mysql-connector-java-5.1.46-bin.jar .
-    rm -rf mysql-connector-java-5.1.46.tar.gz
-    rm -rf mysql-connector-java-5.1.46
+    wget https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-j-8.3.0.tar.gz
+    tar -zxvf mysql-connector-j-8.3.0.tar.gz
+    mv mysql-connector-j-8.3.0/mysql-connector-j-8.3.0.jar .
+    rm -rf mysql-connector-j-8.3.0.tar.gz
+    rm -rf mysql-connector-j-8.3.0
 
 ## Create the MySQL Database
+
 Now we are going to create the database that OneBusAway will use to store user and API data. To do this run the following command:
 
     mysql -p -e "CREATE DATABASE oba; GRANT ALL PRIVILEGES ON oba.* TO 'oba'@'localhost' IDENTIFIED BY 'newPassword';"
 
-In the above commands, replace **newPassword** with something secure. This will be the password for the MySQL user oba who will only have access to the database oba. When prompted for a password, enter the password of the MySQL root user that you set while installing MySQL.
+In the above commands, replace **newPassword** with something secure. This will be the password for the MySQL user oba who will only have access to the database oba. When prompted for a password, enter the root password you set earlier.
 
-## Stop the Tomcat 8 Service
-To prepare for deployment, we need to stop the Tomcat 8 service. To do this run the following command:
+## Stop the Tomcat 9 Service
 
-`service tomcat8 stop`
+To prepare for deployment, we need to stop the Tomcat 9 service. To do this run the following command:
+
+`service tomcat9 stop`
 
 ## Deploy and Configure the OneBusAway Transit Data Federation Webapp
 
 ### Copy The Files
 
-    mkdir /var/lib/tomcat8/webapps/onebusaway-transit-data-federation-webapp
-    cd /var/lib/tomcat8/webapps/onebusaway-transit-data-federation-webapp
-    mv /oba/onebusaway-transit-data-federation-webapp-2.0.0.war /var/lib/tomcat8/webapps/onebusaway-transit-data-federation-webapp
-    jar xvf /var/lib/tomcat8/webapps/onebusaway-transit-data-federation-webapp/onebusaway-transit-data-federation-webapp-2.0.0.war
-    rm -rf /var/lib/tomcat8/webapps/onebusaway-transit-data-federation-webapp/onebusaway-transit-data-federation-webapp-2.0.0.war
+    mkdir /var/lib/tomcat9/webapps/onebusaway-transit-data-federation-webapp
+    cd /var/lib/tomcat9/webapps/onebusaway-transit-data-federation-webapp
+    mv /oba/onebusaway-transit-data-federation-webapp-2.5.12-cs.war /var/lib/tomcat9/webapps/onebusaway-transit-data-federation-webapp
+    jar xvf /var/lib/tomcat9/webapps/onebusaway-transit-data-federation-webapp/onebusaway-transit-data-federation-webapp-2.5.12-cs.war
+    rm -rf /var/lib/tomcat9/webapps/onebusaway-transit-data-federation-webapp/onebusaway-transit-data-federation-webapp-2.5.12-cs.war
 
 ### Copy the MySQL Driver
 
-    cd /var/lib/tomcat8/webapps/onebusaway-transit-data-federation-webapp/WEB-INF/lib
-    cp /oba/mysql-connector-java-5.1.46-bin.jar .
+    cd /var/lib/tomcat9/webapps/onebusaway-transit-data-federation-webapp/WEB-INF/lib
+    cp /oba/mysql-connector-j-8.3.0.jar .
 
 ### Configure the OneBusAway Transit Data Federation Webapp
 
-`nano /var/lib/tomcat8/webapps/onebusaway-transit-data-federation-webapp/WEB-INF/classes/data-sources.xml`
+`nano /var/lib/tomcat9/webapps/onebusaway-transit-data-federation-webapp/WEB-INF/classes/data-sources.xml`
 
 Using the editor, clear out the contents of this file and replace it with:
 
     <?xml version="1.0" encoding="UTF-8"?>
     <beans xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
       <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
-        <property name="driverClassName" value="com.mysql.jdbc.Driver" />
+        <property name="driverClassName" value="com.mysql.cj.jdbc.Driver" />
         <property name="url" value="jdbc:mysql://127.0.0.1/oba?characterEncoding=UTF-8" />
         <property name="username" value="oba" />
         <property name="password" value="newPassword" />
@@ -189,20 +208,20 @@ In the above XML code you will need to replace newPassword in the SQL settings w
 
 ### Copy The Files
 
-    mkdir /var/lib/tomcat8/webapps/onebusaway-api-webapp
-    cd /var/lib/tomcat8/webapps/onebusaway-api-webapp
-    mv /oba/onebusaway-api-webapp-2.0.0-20180106.064748-47.war /var/lib/tomcat8/webapps/onebusaway-api-webapp/
-    jar xvf /var/lib/tomcat8/webapps/onebusaway-api-webapp/onebusaway-api-webapp-2.0.0-20180106.064748-47.war
-    rm -rf /var/lib/tomcat8/webapps/onebusaway-api-webapp/onebusaway-api-webapp-2.0.0-20180106.064748-47.war
+    mkdir /var/lib/tomcat9/webapps/onebusaway-api-webapp
+    cd /var/lib/tomcat9/webapps/onebusaway-api-webapp
+    mv /oba/onebusaway-api-webapp-2.5.12-cs.war /var/lib/tomcat9/webapps/onebusaway-api-webapp/
+    jar xvf /var/lib/tomcat9/webapps/onebusaway-api-webapp/onebusaway-api-webapp-2.5.12-cs.war
+    rm -rf /var/lib/tomcat9/webapps/onebusaway-api-webapp/onebusaway-api-webapp-2.5.12-cs.war
 
 ### Copy the MySQL Driver
 
-    cd /var/lib/tomcat8/webapps/onebusaway-api-webapp/WEB-INF/lib
-    cp /oba/mysql-connector-java-5.1.46-bin.jar .
+    cd /var/lib/tomcat9/webapps/onebusaway-api-webapp/WEB-INF/lib
+    cp /oba/mysql-connector-j-8.3.0.jar .
 
 ### Configure the OneBusAway API Webapp
 
-`nano /var/lib/tomcat8/webapps/onebusaway-api-webapp/WEB-INF/classes/data-sources.xml`
+`nano /var/lib/tomcat9/webapps/onebusaway-api-webapp/WEB-INF/classes/data-sources.xml`
 
     <?xml version="1.0" encoding="UTF-8"?>
     <beans xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
@@ -213,21 +232,18 @@ In the above XML code you will need to replace newPassword in the SQL settings w
       </bean>
       <bean id="apiKeyValidationService" class="org.onebusaway.users.impl.validation.KeyValidationServiceImpl" />
       <!-- Database Configuration -->
-
       <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
-        <property name="driverClassName" value="com.mysql.jdbc.Driver" />
+        <property name="driverClassName" value="com.mysql.cj.jdbc.Driver" />
         <property name="url" value="jdbc:mysql://127.0.0.1/oba?characterEncoding=UTF-8" />
         <property name="username" value="oba" />
         <property name="password" value="newPassword" />
       </bean>
-
       <bean id="agencyMetadataDataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
-        <property name="driverClassName" value="com.mysql.jdbc.Driver" />
+        <property name="driverClassName" value="com.mysql.cj.jdbc.Driver" />
         <property name="url" value="jdbc:mysql://127.0.0.1/oba?characterEncoding=UTF-8" />
         <property name="username" value="oba" />
         <property name="password" value="newPassword" />
       </bean>
-
       <bean id="agencyMetadataSessionFactory" class="org.springframework.orm.hibernate3.annotation.AnnotationSessionFactoryBean">
         <property name="dataSource" ref="agencyMetadataDataSource" />
         <property name="annotatedClasses">
@@ -251,21 +267,13 @@ In the above XML code you will need to replace newPassword in the SQL settings w
           </props>
         </property>
       </bean>
-      <bean class="org.onebusaway.container.spring.PropertyOverrideConfigurer">
-        <property name="properties">
-          <props>
-            <prop key="cacheManager.cacheManagerName">org.onebusaway.api_webapp.cacheManager</prop>
-          </props>
-        </property>
-       </bean>
-
       <!-- Allows the TEST key for OBA API testing.  Should be removed in production -->
       <bean class="org.onebusaway.users.impl.CreateApiKeyAction">
         <property name="key" value="TEST"/>
       </bean>
     </beans>
 
-Take note of the last bean in the XML. This is an API key for testing purposes. It is very important to either change the key or remove it entirely before making your OBA installation live. If you want to allow users to connect to your OBA instance with the various OBA apps, you must include additional beans that have the default API keys for the respective app. You can get the code for these beans from this file before you replace its contents.
+Take note of the second-to-last bean in the XML. This is an API key for testing purposes. It is very important to either change the key or remove it entirely before making your OBA installation live. If you want to allow users to connect to your OBA instance with the various OBA apps, you must include additional beans that have the default API keys for the respective app. You can get the code for these beans from this file before you replace its contents.
 
 Also, in the above XML code you will need to replace newPassword in the SQL settings with the password you chose for the oba user.
 
@@ -273,20 +281,20 @@ Also, in the above XML code you will need to replace newPassword in the SQL sett
 
 ### Copy The Files
 
-    rm -rf /var/lib/tomcat8/webapps/ROOT/*
-    cd /var/lib/tomcat8/webapps/ROOT
-    mv /oba/onebusaway-enterprise-acta-webapp-2.0.0-20180106.065008-42.war /var/lib/tomcat8/webapps/ROOT/
-    jar xvf /var/lib/tomcat8/webapps/ROOT/onebusaway-enterprise-acta-webapp-2.0.0-20180106.065008-42.war
-    rm -rf /var/lib/tomcat8/webapps/ROOT/onebusaway-enterprise-acta-webapp-2.0.0-20180106.065008-42.war
+    rm -rf /var/lib/tomcat9/webapps/ROOT/*
+    cd /var/lib/tomcat9/webapps/ROOT
+    mv /oba/onebusaway-enterprise-acta-webapp-2.5.12-cs.war /var/lib/tomcat9/webapps/ROOT/
+    jar xvf /var/lib/tomcat9/webapps/ROOT/onebusaway-enterprise-acta-webapp-2.5.12-cs.war
+    rm -rf /var/lib/tomcat9/webapps/ROOT/onebusaway-enterprise-acta-webapp-2.5.12-cs.war
 
 ### Copy the MySQL Driver
 
-    cd /var/lib/tomcat8/webapps/ROOT/WEB-INF/lib
-    cp /oba/mysql-connector-java-5.1.46-bin.jar .
+    cd /var/lib/tomcat9/webapps/ROOT/WEB-INF/lib
+    cp /oba/mysql-connector-j-8.3.0.jar .
 
-### Configure the OneBusAway API Webapp
+### Configure the OneBusAway Enterprise ACTA Webapp
 
-`nano /var/lib/tomcat8/webapps/ROOT/WEB-INF/classes/data-sources.xml`
+`nano /var/lib/tomcat9/webapps/ROOT/WEB-INF/classes/data-sources.xml`
 
     <?xml version="1.0" encoding="UTF-8"?>
     <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context" xmlns:aop="http://www.springframework.org/schema/aop" xmlns:jee="http://www.springframework.org/schema/jee" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee-3.0.xsd">
@@ -300,7 +308,7 @@ Also, in the above XML code you will need to replace newPassword in the SQL sett
         </bean>
         <!-- Database Configuration -->
         <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
-            <property name="driverClassName" value="com.mysql.jdbc.Driver" />
+            <property name="driverClassName" value="com.mysql.cj.jdbc.Driver" />
             <property name="url" value="jdbc:mysql://127.0.0.1/oba?characterEncoding=UTF-8" />
             <property name="username" value="oba" />
             <property name="password" value="newPassword" />
@@ -331,26 +339,33 @@ Also, in the above XML code you will need to replace newPassword in the SQL sett
 
 In the above XML code you will need to replace newPassword in the SQL settings with the password you chose for the oba user.
 
-## Start the Tomcat8 Service
-Finally we can start the Tomcat8 Service to see if everything worked. In a second SSH window you may want to run the following command so that you can watch the console output of the Tomcat8 service as OneBusAway starts up for the first time:
+## Start the Tomcat 9 Service
 
-`tail -f /var/log/tomcat8/catalina.out`
+Finally we can start the Tomcat 9 Service to see if everything worked. In a second SSH window you may want to run the following command so that you can watch the console output of the Tomcat 9 service as OneBusAway starts up for the first time:
 
-To start the Tomcat8 Service simply run this command:
+`tail -f /var/log/tomcat9/catalina.out`
 
-`service tomcat8 start`
+To start the Tomcat 9 Service simply run this command:
 
-## Check all of the Services.
+`service tomcat9 start`
+
+## Check all of the Services
+
 OBA v2 uses multiple different services to make sure each one is working correctly you should be able to visit:
 * http://myoba.example.com:8080/routes
 * http://myoba.example.com:8080/onebusaway-transit-data-federation-webapp/
 * http://myoba.example.com:8080/onebusaway-api-webapp/api/where/agencies-with-coverage.json?key=TEST
+
 Each URL should be responding with no errors.
 
 ## Visit Your OneBusAway Installation from a Web Browser
+
 Finally, to use your OneBusAway instance visit http://myoba.example.com:8080/routes
 
 ## Troubleshooting
+
 Here are some suggestions on what adjustments you can make to fix common problems.
+
 ### Real Time Data Not Working
+
 Set your server's timezone to that of the Transit Agency whose data you are accessing.


### PR DESCRIPTION
Closes #118


This PR updates the Configuration and Deployment Guide for v2.x, which was severely outdated. A previous contributor (gorgwu) attempted this in PR #125 but their fork was deleted This PR picks up that work and discussions

## Changes Made

### OS and Software Versions
- **Debian 9 → Ubuntu 22.04 LTS**: Debian 9 is end of life with no security updates. Ubuntu 22.04 is what the official Docker image uses and receives security updates until 2027.
- **JDK 8 → JDK 11**: OBA now requires JDK 11 as a minimum. Updated install command to `openjdk-11-jdk`.
- **Tomcat 8 → Tomcat 9**: Tomcat 8 is not available in Ubuntu 22.04 repos. Tomcat 9 is available via `apt-get` and all paths updated accordingly (`/var/lib/tomcat9/`, `service tomcat9`, etc).
- **MySQL Connector/J 5.1.46 → 8.3.0**: Updated to match MySQL 8. Filename format also changed from `mysql-connector-java-5.1.46-bin.jar` to `mysql-connector-j-8.3.0.jar`.

### MySQL Installation
- Ubuntu 22.04 has MySQL 8.0 directly in its repos — the old manual apt-config `.deb` method is no longer needed.
- MySQL 8 no longer auto-prompts for a root password during install. Added manual root password setup commands using `ALTER USER`.

### Download URLs
- Replaced all hardcoded `2.0.0` version URLs pointing to the dead nexus server with current version `2.5.12-cs` from the Cambridge Systematics repo.
- Added a note instructing users to check the [Downloads](/downloads) page and substitute the latest version number if a newer one is available.
- Note: Dynamic version substitution via `site_metadata.yml` is not possible in `.md` files (only `.erb`), so the version is kept as a static string with clear instructions.

### data-sources.xml Updates
- Updated MySQL driver class from the deprecated `com.mysql.jdbc.Driver` to `com.mysql.cj.jdbc.Driver` in all three webapp configs (federation, API, enterprise). This is required for MySQL 8 compatibility.
- Placeholder passwords clearly marked for replacement.
- GTFS realtime configuration preserved.
- Duplicate `PropertyOverrideConfigurer` bean removed from API webapp config.

### Text Fixes
- Removed the blue "out of date" `<div>` at the top (as requested by @aaronbrethorst in PR #125 — it was added to flag the guide as outdated, and these changes fix that).
- Added a Docker recommendation note at the top directing new users to the official Docker deployment guide.
- Fixed "second-to-last" (was "second-last") in API webapp section.
- Various minor grammar and clarity improvements.

## What Was Not Changed
- The data-sources.xml structure was kept largely intact. @aaronbrethorst suggested inspecting a live Docker container to get the latest versions — this is flagged as a follow-up.
- Live server testing on Ubuntu 22.04 + Tomcat 9 was not performed (no server available). Commands are based on known Ubuntu 22.04 package availability and MySQL 8 behavior. 


PTAL @aaronbrethorst 
I would make the changes sugegsted by you!
thank you